### PR TITLE
refactor: Como aplicação leva ao menos 1 segundo para ser iniciada, a…

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -26,6 +26,7 @@ jobs:
       run: dotnet test Back-End_Challenge_20210221.sln --no-build --verbosity normal
 
   docker:
+    needs: tests
     runs-on: ubuntu-latest
     
     steps:

--- a/Back-End_Challenge_20210221/Infra/Cron/CronService.cs
+++ b/Back-End_Challenge_20210221/Infra/Cron/CronService.cs
@@ -31,7 +31,7 @@ public class CronService : IHostedService, IDisposable
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _logger.LogInformation("StartAsync {UtcNow}. Init in {ImportRange} minutes", DateTime.UtcNow, _importRange.Minutes);
+        _logger.LogInformation("StartAsync {UtcNow}. Init in {ImportRange} minutes", DateTime.UtcNow, _importRange.TotalMinutes);
         _iterations = _importLimit / _take;
         _timer = new Timer(ImportData, null, _importRange, TimeSpan.FromDays(1));
         return Task.CompletedTask;

--- a/Back-End_Challenge_20210221/Program.cs
+++ b/Back-End_Challenge_20210221/Program.cs
@@ -84,7 +84,7 @@ var app = builder.Build();
 var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
 lifetime.ApplicationStarted.Register(() =>
 {
-    Console.WriteLine($"Time (ms) to Startup Application: {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds}");
+    Console.WriteLine($"Time (seconds) to Startup Application: {Stopwatch.GetElapsedTime(startTime).TotalSeconds}");
 });
 
 using IServiceScope scope = app.Services.CreateScope();


### PR DESCRIPTION
…lterada unidade de medida no log do início da aplicação de milissegundos para segundos

- Para realizar etapa do docker apenas quando os testes passarem, adicionada configuração em 'dotnet-ci', que informa a dependência do 'docker' na tarefa bem-sucedida de 'tests';
- Alterada propriedade do 'TimeSpan' a ser exibida no log do 'CronService' (o certo é a propriedade 'TotalMinutes');